### PR TITLE
클래스 신청 목록 화면 UI 구현

### DIFF
--- a/ClassManager.xcodeproj/project.pbxproj
+++ b/ClassManager.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AB2A426C28F6DF5600B314B9 /* Enrollment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2A426B28F6DF5600B314B9 /* Enrollment.swift */; };
 		C0552C2928F69541005D0E67 /* ClassManagerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0552C2828F69541005D0E67 /* ClassManagerApp.swift */; };
 		C0552C2D28F69542005D0E67 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C0552C2C28F69542005D0E67 /* Assets.xcassets */; };
 		C0552C3128F69542005D0E67 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C0552C3028F69542005D0E67 /* Preview Assets.xcassets */; };
@@ -48,6 +49,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		AB2A426B28F6DF5600B314B9 /* Enrollment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enrollment.swift; sourceTree = "<group>"; };
 		C0552C2528F69541005D0E67 /* ClassManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ClassManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0552C2828F69541005D0E67 /* ClassManagerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassManagerApp.swift; sourceTree = "<group>"; };
 		C0552C2C28F69542005D0E67 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -181,6 +183,7 @@
 				C79E13BF28F6B1780010C4BA /* Class.swift */,
 				C79E13C128F6B2990010C4BA /* Hall.swift */,
 				C79E13C328F6B2BD0010C4BA /* Applicant.swift */,
+				AB2A426B28F6DF5600B314B9 /* Enrollment.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -368,6 +371,7 @@
 				C79E13D928F6BD540010C4BA /* Toast.swift in Sources */,
 				C79E13BC28F6AF8B0010C4BA /* Studio.swift in Sources */,
 				C79E13C928F6BBBC0010C4BA /* AddClassView.swift in Sources */,
+				AB2A426C28F6DF5600B314B9 /* Enrollment.swift in Sources */,
 				C79E13BE28F6B0DC0010C4BA /* Notice.swift in Sources */,
 				C79E13CB28F6BC010010C4BA /* OnboardingView.swift in Sources */,
 				C79E13C428F6B2BD0010C4BA /* Applicant.swift in Sources */,

--- a/ClassManager.xcodeproj/project.pbxproj
+++ b/ClassManager.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		AB2A426C28F6DF5600B314B9 /* Enrollment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2A426B28F6DF5600B314B9 /* Enrollment.swift */; };
+		AB2A427028F6E2D000B314B9 /* EnrollmentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2A426F28F6E2D000B314B9 /* EnrollmentListView.swift */; };
 		C0552C2928F69541005D0E67 /* ClassManagerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0552C2828F69541005D0E67 /* ClassManagerApp.swift */; };
 		C0552C2D28F69542005D0E67 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C0552C2C28F69542005D0E67 /* Assets.xcassets */; };
 		C0552C3128F69542005D0E67 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C0552C3028F69542005D0E67 /* Preview Assets.xcassets */; };
@@ -50,6 +51,7 @@
 
 /* Begin PBXFileReference section */
 		AB2A426B28F6DF5600B314B9 /* Enrollment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enrollment.swift; sourceTree = "<group>"; };
+		AB2A426F28F6E2D000B314B9 /* EnrollmentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrollmentListView.swift; sourceTree = "<group>"; };
 		C0552C2528F69541005D0E67 /* ClassManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ClassManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0552C2828F69541005D0E67 /* ClassManagerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassManagerApp.swift; sourceTree = "<group>"; };
 		C0552C2C28F69542005D0E67 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -194,6 +196,7 @@
 				C79E13C628F6BBB00010C4BA /* ClassCalendarView.swift */,
 				C79E13C828F6BBBC0010C4BA /* AddClassView.swift */,
 				C79E13CA28F6BC010010C4BA /* OnboardingView.swift */,
+				AB2A426F28F6E2D000B314B9 /* EnrollmentListView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -375,6 +378,7 @@
 				C79E13BE28F6B0DC0010C4BA /* Notice.swift in Sources */,
 				C79E13CB28F6BC010010C4BA /* OnboardingView.swift in Sources */,
 				C79E13C428F6B2BD0010C4BA /* Applicant.swift in Sources */,
+				AB2A427028F6E2D000B314B9 /* EnrollmentListView.swift in Sources */,
 				C79E13C228F6B2990010C4BA /* Hall.swift in Sources */,
 				C79E13C728F6BBB00010C4BA /* ClassCalendarView.swift in Sources */,
 				C79E13C028F6B1780010C4BA /* Class.swift in Sources */,

--- a/ClassManager/Model/Enrollment.swift
+++ b/ClassManager/Model/Enrollment.swift
@@ -1,0 +1,16 @@
+//
+//  Enrollment.swift
+//  ClassManager
+//
+//  Created by 김남건 on 2022/10/12.
+//
+
+import Foundation
+
+struct Enrollment {
+    let ID: String
+    let classID: String?
+    let number: Int?
+    let enrolledDate: Date?
+    let paid: Bool?
+}

--- a/ClassManager/Model/Enrollment.swift
+++ b/ClassManager/Model/Enrollment.swift
@@ -11,6 +11,8 @@ struct Enrollment {
     let ID: String
     let classID: String?
     let number: Int?
+    let userName: String?
+    let phoneNumber: String?
     let enrolledDate: Date?
     let paid: Bool?
 }

--- a/ClassManager/View/EnrollmentListView.swift
+++ b/ClassManager/View/EnrollmentListView.swift
@@ -11,8 +11,15 @@ struct EnrollmentListView: View {
     let enrolledClass = Class(ID: "id1234", studioID: "studio1111", title: "Narae의 팝업 클래스", instructorName: "Narae", date: Date(), durationMinute: 60, repetition: nil, hall: Hall(name: "Hall A", capacity: 30), applicantsCount: nil)
     
     var body: some View {
-        VStack(spacing: 17) {
+        VStack(alignment: .leading, spacing: 17) {
             classBanner
+            VStack(alignment: .leading, spacing: 6) {
+                Text("신청내역")
+                    .fontWeight(.bold)
+            }
+            .padding(.leading, 24)
+            .padding(.trailing, 9)
+                
         }
         .navigationTitle(enrolledClass.title ?? "기본 타이틀")
         .navigationBarTitleDisplayMode(.inline)

--- a/ClassManager/View/EnrollmentListView.swift
+++ b/ClassManager/View/EnrollmentListView.swift
@@ -10,6 +10,19 @@ import SwiftUI
 struct EnrollmentListView: View {
     let enrolledClass = Class(ID: "id1234", studioID: "studio1111", title: "Narae의 팝업 클래스", instructorName: "Narae", date: Date(), durationMinute: 60, repetition: nil, hall: Hall(name: "Hall A", capacity: 30), applicantsCount: nil)
     
+    let dummyData = [
+        Enrollment(ID: "1", classID: "1", number: 1, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: false),
+        Enrollment(ID: "2", classID: "1", number: 2, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
+        Enrollment(ID: "3", classID: "1", number: 3, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
+        Enrollment(ID: "4", classID: "1", number: 4, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
+        Enrollment(ID: "5", classID: "1", number: 5, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
+        Enrollment(ID: "6", classID: "1", number: 6, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
+        Enrollment(ID: "7", classID: "1", number: 7, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
+        Enrollment(ID: "8", classID: "1", number: 8, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
+        Enrollment(ID: "9", classID: "1", number: 9, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
+        Enrollment(ID: "10", classID: "1", number: 10, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
+    ]
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 17) {
             classBanner

--- a/ClassManager/View/EnrollmentListView.swift
+++ b/ClassManager/View/EnrollmentListView.swift
@@ -11,16 +11,16 @@ struct EnrollmentListView: View {
     let enrolledClass = Class(ID: "id1234", studioID: "studio1111", title: "Narae의 팝업 클래스", instructorName: "Narae", date: Date(), durationMinute: 60, repetition: nil, hall: Hall(name: "Hall A", capacity: 30), applicantsCount: nil)
     
     let dummyData = [
-        Enrollment(ID: "1", classID: "1", number: 1, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: false),
-        Enrollment(ID: "2", classID: "1", number: 2, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
-        Enrollment(ID: "3", classID: "1", number: 3, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
-        Enrollment(ID: "4", classID: "1", number: 4, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
-        Enrollment(ID: "5", classID: "1", number: 5, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
-        Enrollment(ID: "6", classID: "1", number: 6, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
-        Enrollment(ID: "7", classID: "1", number: 7, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
-        Enrollment(ID: "8", classID: "1", number: 8, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
-        Enrollment(ID: "9", classID: "1", number: 9, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
-        Enrollment(ID: "10", classID: "1", number: 10, userName: "강지인", phoneNumber: "01012345678", enrolledDate: Date(), paid: true),
+        Enrollment(ID: "1", classID: "1", number: 1, userName: "강지인", phoneNumber: "010-1234-5678", enrolledDate: Date(), paid: false),
+        Enrollment(ID: "2", classID: "1", number: 2, userName: "강지인", phoneNumber: "010-1234-5678", enrolledDate: Date() - 60.0, paid: true),
+        Enrollment(ID: "3", classID: "1", number: 3, userName: "강지인", phoneNumber: "010-1234-5678", enrolledDate: Date() - 120.0, paid: true),
+        Enrollment(ID: "4", classID: "1", number: 4, userName: "강지인", phoneNumber: "010-1234-5678", enrolledDate: Date(), paid: true),
+        Enrollment(ID: "5", classID: "1", number: 5, userName: "강지인", phoneNumber: "010-1234-5678", enrolledDate: Date(), paid: true),
+        Enrollment(ID: "6", classID: "1", number: 6, userName: "강지인", phoneNumber: "010-1234-5678", enrolledDate: Date(), paid: true),
+        Enrollment(ID: "7", classID: "1", number: 7, userName: "강지인", phoneNumber: "010-1234-5678", enrolledDate: Date(), paid: true),
+        Enrollment(ID: "8", classID: "1", number: 8, userName: "강지인", phoneNumber: "010-1234-5678", enrolledDate: Date(), paid: true),
+        Enrollment(ID: "9", classID: "1", number: 9, userName: "강지인", phoneNumber: "010-1234-5678", enrolledDate: Date(), paid: true),
+        Enrollment(ID: "10", classID: "1", number: 10, userName: "강지인", phoneNumber: "010-1234-5678", enrolledDate: Date(), paid: true),
     ]
     
     var body: some View {
@@ -29,6 +29,7 @@ struct EnrollmentListView: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("신청내역")
                     .fontWeight(.bold)
+                table
             }
             .padding(.leading, 24)
             .padding(.trailing, 9)
@@ -64,6 +65,51 @@ struct EnrollmentListView: View {
         .padding(.horizontal, 24)
     }
     
+    var table: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Divider()
+                .padding(.trailing, 15)
+                .padding(.bottom, 6)
+            HStack(spacing: 0) {
+                Text("No.")
+                    .padding(.trailing, 22)
+                Text("성명")
+                    .padding(.trailing, 44)
+                Text("연락처")
+                    .padding(.trailing, 41)
+                Text("신청시각")
+                    .padding(.trailing, 41)
+                Text("상태")
+            }
+            .padding(.bottom, 12)
+            tableRows
+        }
+    }
+    
+    var tableRows: some View {
+        ScrollView(showsIndicators: false) {
+            LazyVStack(spacing: 20) {
+                ForEach(dummyData, id: \.ID) { enrollment in
+                    HStack(spacing: 0) {
+                        Text("\(enrollment.number ?? 0)")
+                            .frame(width: 25)
+                            .padding(.trailing, 14)
+                        Text(enrollment.userName ?? "익명")
+                            .frame(width: 50)
+                            .padding(.trailing, 27)
+                        Text(getFormattedPhoneNumberString(from: enrollment.phoneNumber ?? "xxx-xxxx-xxxx"))
+                            .multilineTextAlignment(.trailing)
+                            .padding(.trailing, 29)
+                        Text("\(getMinutesAgo(from: enrollment.enrolledDate))분 전")
+                            .padding(.trailing, 28)
+                        Text(getPaidStatusString(from: enrollment.paid))
+                            .foregroundColor((enrollment.paid ?? false) ? Color("Del") : Color(uiColor: UIColor.label))
+                    }
+                }
+            }
+        }
+    }
+    
     private func getTimeString(from date: Date?) -> String {
         if let date {
             let dateFormatter = DateFormatter()
@@ -73,6 +119,34 @@ struct EnrollmentListView: View {
         } else {
             return "xx:xx"
         }
+    }
+    
+    private func getFormattedPhoneNumberString(from phoneNumber: String?) -> String {
+        guard let phoneNumber else {
+            return "xxx-xxxx-\nxxxx"
+        }
+        
+        let arr = phoneNumber.components(separatedBy: "-")
+        
+        return "\(arr[0])-\(arr[1])\n-\(arr[2])"
+    }
+    
+    private func getMinutesAgo(from date: Date?) -> Int {
+        guard let date else {
+            return 0
+        }
+        
+        let timeInterval = Date().timeIntervalSince(date)
+        
+        return Int(timeInterval / 60)
+    }
+    
+    private func getPaidStatusString(from paid: Bool?) -> String {
+        guard let paid else {
+            return "에러발생"
+        }
+        
+        return paid ? "결제완료" : "결제대기"
     }
 }
 

--- a/ClassManager/View/EnrollmentListView.swift
+++ b/ClassManager/View/EnrollmentListView.swift
@@ -72,13 +72,13 @@ struct EnrollmentListView: View {
                 .padding(.bottom, 6)
             HStack(spacing: 0) {
                 Text("No.")
-                    .padding(.trailing, 22)
+                    .padding(.trailing, 27)
                 Text("성명")
-                    .padding(.trailing, 44)
+                    .padding(.trailing, 47)
                 Text("연락처")
-                    .padding(.trailing, 41)
+                    .padding(.trailing, 38)
                 Text("신청시각")
-                    .padding(.trailing, 41)
+                    .padding(.trailing, 35)
                 Text("상태")
             }
             .padding(.bottom, 12)

--- a/ClassManager/View/EnrollmentListView.swift
+++ b/ClassManager/View/EnrollmentListView.swift
@@ -1,0 +1,65 @@
+//
+//  EnrollmentListView.swift
+//  ClassManager
+//
+//  Created by 김남건 on 2022/10/12.
+//
+
+import SwiftUI
+
+struct EnrollmentListView: View {
+    let enrolledClass = Class(ID: "id1234", studioID: "studio1111", title: "Narae의 팝업 클래스", instructorName: "Narae", date: Date(), durationMinute: 60, repetition: nil, hall: Hall(name: "Hall A", capacity: 30), applicantsCount: nil)
+    
+    var body: some View {
+        VStack(spacing: 17) {
+            classBanner
+        }
+        .navigationTitle(enrolledClass.title ?? "기본 타이틀")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    var classBanner: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 13, style: .circular)
+                .foregroundColor(Color("Box"))
+            HStack {
+                VStack(alignment: .leading) {
+                    Text(enrolledClass.hall?.name ?? "기본 홀")
+                    Spacer()
+                    Text(enrolledClass.title ?? "기본 타이틀")
+                        .bold()
+                }
+                Spacer()
+                VStack {
+                    Text(getTimeString(from: enrolledClass.date))
+                    Spacer()
+                    Text(getTimeString(from: (enrolledClass.date ?? Date()) + Double(enrolledClass.durationMinute ?? 0) * 60))
+                }
+            }
+            .padding(.top, 14)
+            .padding(.bottom, 17)
+            .padding(.horizontal, 17)
+        }
+        .frame(height: 77)
+        .padding(.horizontal, 24)
+    }
+    
+    private func getTimeString(from date: Date?) -> String {
+        if let date {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "HH:mm"
+            
+            return dateFormatter.string(from: date)
+        } else {
+            return "xx:xx"
+        }
+    }
+}
+
+struct EnrollmentListView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            EnrollmentListView()
+        }
+    }
+}


### PR DESCRIPTION
## 개요
* 클래스 신청 목록 화면 UI 구현

## 작업 내용
* 클래스와 신청 데이터에 dummy 값 사용
* 전체적으로 클래스 배너와 테이블로 구성
* table의 각 row를 `HStack`으로 구현 (header 포함)
    * 각 column에 trailing 방향으로 padding 부여
* 신청 목록들의 `LazyVStack`을 `ScrollView`로 감쌈

## 고민사항
* 테이블 뷰를 grid로 할 수 있을까?
    * column 간의 간격이 불규칙하다는게 문제

## 테스트 방법(optional)
* `EnrollmentListView`의 preview 확인하기

## 스크린샷

https://user-images.githubusercontent.com/40821203/195382407-a78ce2af-404a-4120-bd91-504f3d8275ab.mov


