### PR TITLE
[FIX] timestamp logic of Enrollment model, view

### DIFF
--- a/ClassManager/Model/Enrollment.swift
+++ b/ClassManager/Model/Enrollment.swift
@@ -33,7 +33,7 @@ struct Enrollment {
         self.number = documentSnapShot["number"] as? Int
         self.userName = documentSnapShot["userName"] as? String
         self.phoneNumber = documentSnapShot["phoneNumber"] as? String
-        self.enrolledDate = documentSnapShot["enrolledDate"] as? Date
+        self.enrolledDate = (documentSnapShot["enrolledDate"] as? Timestamp)!.dateValue()
         self.paid = documentSnapShot["paid"] as? Bool
     }
 }

--- a/ClassManager/View/EnrollmentListView.swift
+++ b/ClassManager/View/EnrollmentListView.swift
@@ -91,8 +91,16 @@ struct EnrollmentListView: View {
                         Text(getFormattedPhoneNumberString(from: enrollment.phoneNumber ?? "xxx-xxxx-xxxx"))
                             .multilineTextAlignment(.trailing)
                             .frame(width: 70)
-                        Text("\(getMinutesAgo(from: enrollment.enrolledDate))분 전")
-                            .frame(width: 60)
+                        if getMinutesAgo(from: enrollment.enrolledDate) < 60 {
+                            Text("\(getMinutesAgo(from: enrollment.enrolledDate))분 전")
+                                .frame(width: 60)
+                        } else if getMinutesAgo(from: enrollment.enrolledDate) / 60 < 24 {
+                            Text("\(getMinutesAgo(from: enrollment.enrolledDate) / 60)시간 전")
+                                .frame(width: 60)
+                        } else {
+                            Text("\(getMinutesAgo(from: enrollment.enrolledDate) / 1440)일 전")
+                                .frame(width: 60)
+                        }
                         Text(getPaidStatusString(from: enrollment.paid))
                             .foregroundColor((enrollment.paid ?? false) ? Color("Del") : Color(uiColor: UIColor.label))
                             .frame(width: 60)


### PR DESCRIPTION
## 개요

Enrollment 관련 Model, View에서 timestamp 관련 로직을 전부 수정했습니다.

## 작업 내용

* `documentSnapShot` -> `Enrollment` 파싱 변경: Timestamp.dateValue()로 변경
* m분 전, h시간 전, d일 전

## 고민사항

* Firestore에서 timestamp가 null인 케이스가 없어서 옵셔널 강제추출 했습니다.

## 스크린샷
![image](https://user-images.githubusercontent.com/76807762/195650896-ed34b759-862d-4505-ade8-47b484771c23.png)

