### PR TITLE
EnrollmentListView UI 및 sorting 수정

### DIFF
--- a/ClassManager/Model/Enrollment.swift
+++ b/ClassManager/Model/Enrollment.swift
@@ -33,7 +33,7 @@ struct Enrollment {
         self.number = documentSnapShot["number"] as? Int
         self.userName = documentSnapShot["userName"] as? String
         self.phoneNumber = documentSnapShot["phoneNumber"] as? String
-        self.enrolledDate = (documentSnapShot["enrolledDate"] as? Timestamp)!.dateValue()
+        self.enrolledDate = (documentSnapShot["enrolledDate"] as? Timestamp)?.dateValue() ?? Date()
         self.paid = documentSnapShot["paid"] as? Bool
     }
 }

--- a/ClassManager/View/EnrollmentListView.swift
+++ b/ClassManager/View/EnrollmentListView.swift
@@ -14,19 +14,18 @@ struct EnrollmentListView: View {
     @State private var enrollmentList = [Enrollment]()
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 17) {
+        VStack(alignment: .leading, spacing: 23) {
             classBanner
-            VStack(alignment: .leading, spacing: 6) {
+                .padding(.top, 18)
+            VStack(alignment: .leading, spacing: 12) {
                 Text("신청내역")
                     .fontWeight(.bold)
                 table
             }
-            .padding(.leading, 24)
-            .padding(.trailing, 9)
-                
         }
         .navigationTitle(enrolledClass.title ?? "기본 타이틀")
         .navigationBarTitleDisplayMode(.inline)
+        .padding(.horizontal, 20)
         .onAppear { attachListener() }
     }
     
@@ -37,8 +36,10 @@ struct EnrollmentListView: View {
             HStack {
                 VStack(alignment: .leading) {
                     Text((enrolledClass.hall?.name ?? "기본") + " 홀")
+                        .font(.subheadline)
                     Spacer()
                     Text(enrolledClass.title ?? "기본 타이틀")
+                        .font(.callout)
                         .bold()
                 }
                 Spacer()
@@ -47,20 +48,19 @@ struct EnrollmentListView: View {
                     Spacer()
                     Text(getTimeString(from: (enrolledClass.date ?? Date()) + Double(enrolledClass.durationMinute ?? 0) * 60))
                 }
+                .font(.system(size: 15))
             }
             .padding(.top, 14)
             .padding(.bottom, 17)
-            .padding(.horizontal, 17)
+            .padding(.horizontal, 20)
         }
         .frame(height: 77)
-        .padding(.horizontal, 24)
     }
     
     var table: some View {
         VStack(alignment: .leading, spacing: 0) {
             Divider()
-                .padding(.trailing, 15)
-                .padding(.bottom, 6)
+                .padding(.bottom, 12)
             HStack(spacing: 22) {
                 Text("No.")
                     .frame(width: 27)
@@ -73,7 +73,7 @@ struct EnrollmentListView: View {
                 Text("상태")
                     .frame(width: 60)
             }
-            .padding(.bottom, 12)
+            .padding(.bottom, 20)
             tableRows
         }
         .font(.system(size: 15))
@@ -81,9 +81,9 @@ struct EnrollmentListView: View {
     
     var tableRows: some View {
         ScrollView(showsIndicators: false) {
-            LazyVStack(spacing: 20) {
+            LazyVStack(spacing: 15) {
                 ForEach(enrollmentList, id: \.ID) { enrollment in
-                    HStack(spacing: 22) {
+                    HStack(alignment: .top, spacing: 22) {
                         Text("\(enrollment.number ?? 0)")
                             .frame(width: 27)
                         Text(enrollment.userName ?? "익명")
@@ -167,7 +167,7 @@ struct EnrollmentListView: View {
 struct EnrollmentListView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            EnrollmentListView(enrolledClass: Class(ID: "07172CCF-CE6B-48EE-94F6-983CE4CF4185", studioID: "studio1111", title: "Narae의 팝업 클래스", instructorName: "Narae", date: Date(), durationMinute: 60, hall: Hall(name: "Hall A", capacity: 30), applicantsCount: nil))
+            EnrollmentListView(enrolledClass: Class(ID: "10725BA3-0919-47E1-A2F4-1433EF293055", studioID: "studio1111", title: "레이븐의 힙합 클래스", instructorName: "Narae", date: Date(), durationMinute: 60, hall: Hall(name: "A", capacity: 30), applicantsCount: nil))
         }
     }
 }

--- a/ClassManager/View/EnrollmentListView.swift
+++ b/ClassManager/View/EnrollmentListView.swift
@@ -101,7 +101,7 @@ struct EnrollmentListView: View {
                             .frame(width: 27)
                         Text(enrollment.userName ?? "익명")
                             .frame(width: 50)
-                        Text(getFormattedPhoneNumberString(from: enrollment.phoneNumber ?? "xxx-xxxx-xxxx"))
+                        Text(enrollment.phoneNumber ?? "xxx-xxxx-xxxx")
                             .multilineTextAlignment(.leading)
                             .frame(width: 70)
                         if getMinutesAgo(from: enrollment.enrolledDate) < 60 {
@@ -132,16 +132,6 @@ struct EnrollmentListView: View {
         } else {
             return "xx:xx"
         }
-    }
-    
-    private func getFormattedPhoneNumberString(from phoneNumber: String?) -> String {
-        guard let phoneNumber else {
-            return "xxx-xxxx-\nxxxx"
-        }
-        
-        let arr = phoneNumber.components(separatedBy: "-")
-        
-        return "\(arr[0])-\(arr[1])\n-\(arr[2])"
     }
     
     private func getMinutesAgo(from date: Date?) -> Int {

--- a/ClassManager/View/EnrollmentListView.swift
+++ b/ClassManager/View/EnrollmentListView.swift
@@ -12,6 +12,7 @@ struct EnrollmentListView: View {
     let enrolledClass: Class
     
     @State private var enrollmentList = [Enrollment]()
+    @Environment(\.presentationMode) private var presentationMode
     
     var body: some View {
         VStack(alignment: .leading, spacing: 23) {
@@ -27,6 +28,18 @@ struct EnrollmentListView: View {
         .navigationBarTitleDisplayMode(.inline)
         .padding(.horizontal, 20)
         .onAppear { attachListener() }
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    presentationMode.wrappedValue.dismiss()
+                } label: {
+                    Image(systemName: "chevron.backward")
+                        .foregroundColor(.init(uiColor: .label))
+                }
+
+            }
+        }
     }
     
     var classBanner: some View {

--- a/ClassManager/View/EnrollmentListView.swift
+++ b/ClassManager/View/EnrollmentListView.swift
@@ -85,6 +85,7 @@ struct EnrollmentListView: View {
                 Text("상태")
                     .frame(width: 60)
             }
+            .foregroundColor(Color("Gray"))
             .padding(.bottom, 20)
             tableRows
         }
@@ -93,7 +94,7 @@ struct EnrollmentListView: View {
     
     var tableRows: some View {
         ScrollView(showsIndicators: false) {
-            LazyVStack(spacing: 15) {
+            LazyVStack(spacing: 16) {
                 ForEach(enrollmentList, id: \.ID) { enrollment in
                     HStack(alignment: .top, spacing: 22) {
                         Text("\(enrollment.number ?? 0)")

--- a/ClassManager/View/EnrollmentListView.swift
+++ b/ClassManager/View/EnrollmentListView.swift
@@ -33,28 +33,27 @@ struct EnrollmentListView: View {
         ZStack {
             RoundedRectangle(cornerRadius: 13, style: .circular)
                 .foregroundColor(Color("Box"))
-            HStack {
-                VStack(alignment: .leading) {
-                    Text((enrolledClass.hall?.name ?? "기본") + " 홀")
-                        .font(.subheadline)
-                    Spacer()
-                    Text(enrolledClass.title ?? "기본 타이틀")
-                        .font(.callout)
-                        .bold()
+            LazyVStack(alignment: .leading, spacing: 4) {
+                Text((enrolledClass.hall?.name ?? "기본") + " 홀")
+                    .foregroundColor(Color("Gray"))
+                    .font(.subheadline)
+                HStack(spacing: 0) {
+                    if let instructorName = enrolledClass.instructorName {
+                        Text("\(instructorName)")
+                            .fontWeight(.semibold)
+                    }
+                    if let title = enrolledClass.title {
+                        Text("의 \(title)")
+                    }
                 }
-                Spacer()
-                VStack {
-                    Text(getTimeString(from: enrolledClass.date))
-                    Spacer()
-                    Text(getTimeString(from: (enrolledClass.date ?? Date()) + Double(enrolledClass.durationMinute ?? 0) * 60))
-                }
-                .font(.system(size: 15))
+                Text("\(getTimeString(from: enrolledClass.date)) - \(getTimeString(from: (enrolledClass.date ?? Date()) + TimeInterval(enrolledClass.durationMinute ?? 0) * 60))")
+                    .foregroundColor(Color("Gray"))
+                    .font(.system(size: 15))
             }
-            .padding(.top, 14)
-            .padding(.bottom, 17)
+            .padding(.vertical, 16)
             .padding(.horizontal, 20)
         }
-        .frame(height: 77)
+        .frame(maxHeight: 106)
     }
     
     var table: some View {
@@ -162,12 +161,20 @@ struct EnrollmentListView: View {
                     })
             }
     }
+    
+    var classDescription: String {
+        guard let instructorName = enrolledClass.instructorName else {
+            return enrolledClass.title ?? "수업"
+        }
+        
+        return "\(instructorName)의 \(enrolledClass.title ?? "수업")"
+    }
 }
 
 struct EnrollmentListView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            EnrollmentListView(enrolledClass: Class(ID: "10725BA3-0919-47E1-A2F4-1433EF293055", studioID: "studio1111", title: "레이븐의 힙합 클래스", instructorName: "Narae", date: Date(), durationMinute: 60, hall: Hall(name: "A", capacity: 30), applicantsCount: nil))
+            EnrollmentListView(enrolledClass: Class(ID: "10725BA3-0919-47E1-A2F4-1433EF293055", studioID: "studio1111", title: "힙합 클래스", instructorName: "레이븐", date: Date(), durationMinute: 60, hall: Hall(name: "A", capacity: 30), applicantsCount: nil))
         }
     }
 }

--- a/ClassManager/View/EnrollmentListView.swift
+++ b/ClassManager/View/EnrollmentListView.swift
@@ -89,7 +89,7 @@ struct EnrollmentListView: View {
                         Text(enrollment.userName ?? "익명")
                             .frame(width: 50)
                         Text(getFormattedPhoneNumberString(from: enrollment.phoneNumber ?? "xxx-xxxx-xxxx"))
-                            .multilineTextAlignment(.trailing)
+                            .multilineTextAlignment(.leading)
                             .frame(width: 70)
                         if getMinutesAgo(from: enrollment.enrolledDate) < 60 {
                             Text("\(getMinutesAgo(from: enrollment.enrolledDate))분 전")

--- a/ClassManager/View/EnrollmentListView.swift
+++ b/ClassManager/View/EnrollmentListView.swift
@@ -36,7 +36,7 @@ struct EnrollmentListView: View {
                 .foregroundColor(Color("Box"))
             HStack {
                 VStack(alignment: .leading) {
-                    Text(enrolledClass.hall?.name ?? "기본 홀")
+                    Text((enrolledClass.hall?.name ?? "기본") + " 홀")
                     Spacer()
                     Text(enrolledClass.title ?? "기본 타이틀")
                         .bold()

--- a/ClassManager/View/EnrollmentListView.swift
+++ b/ClassManager/View/EnrollmentListView.swift
@@ -170,7 +170,11 @@ struct EnrollmentListView: View {
                 }
                 enrollmentList = documents.map { Enrollment(documentSnapShot: $0) }
                     .sorted(by: {
-                        $0.enrolledDate ?? Date() > $1.enrolledDate ?? Date()
+                        if $0.paid ?? false != $1.paid ?? false {
+                            return $0.paid == false
+                        }
+                        
+                        return $0.number ?? 0 > $1.number ?? 0
                     })
             }
     }


### PR DESCRIPTION
## 개요
* `EnrollmentListView`의 UI 및 sorting 방식 수정

## 작업 내용
* 홀 이름 뒤에 "홀" 붙이기
* 연락처 왼쪽 정렬
* 화면 좌우 패딩 20px
* 상단 배너 세 줄로 수정
* back button에서 "Back"를 삭제
* 신청내역 정렬 로직 변경

## 고민사항
* 없음

## 테스트 방법(optional)
* `EnrollmentListView`의 preview 확인

## 스크린샷
<img width="228" alt="스크린샷 2022-10-24 오후 5 32 58" src="https://user-images.githubusercontent.com/40821203/197483289-978d21bf-821e-4dce-8bde-45759bfc9614.png">
