### PR TITLE
[FIX] change present style sheet to full sheet

### DIFF
--- a/ClassManager/View/ClassCalendarView.swift
+++ b/ClassManager/View/ClassCalendarView.swift
@@ -43,7 +43,7 @@ struct ClassCalendarView: View {
             }
             .toast(message: "클래스가 추가되었습니다", isShowing: $isShowingSaveToast, duration: Toast.short)
             .toast(message: "신청폼 링크가 복사되었습니다", isShowing: $isShowingLinkToast, duration: Toast.short)
-            .sheet(isPresented: $isShowingAddSheet) {
+            .fullScreenCover(isPresented: $isShowingAddSheet) {
                 AddClassView(isShowingAddSheet: $isShowingAddSheet, isShowingToast: $isShowingSaveToast, date: selectedDate)
             }
             .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
## 개요
메인화면에서 버튼이 작동하지 않던 버그를 수정했습니다.
원인은 swiftui의 sheet 버그였고 fullsheet로 present mode를 변경후에는 정상적으로 작동합니다.

stackoverflow
[SwiftUI - Navigation bar button not clickable after sheet has been presented](https://stackoverflow.com/questions/58512344/swiftui-navigation-bar-button-not-clickable-after-sheet-has-been-presented)

## 작업 내용
- #19 

## 고민사항
이런 버그는 처음봐서 너무 당황했다.
신기하게도 iphone14 pro에서는 문제가 발생하지 않았고 iphone13에서는 문제가 간혈적으로 발생했다.
sheet 형태로도 하드코딩을 해서 해결하는 방법이 있기는 한데 당분간은 full sheet를 쓰는게 안전할듯.

## 스크린샷
<img src = "https://user-images.githubusercontent.com/57349859/197937436-53dbae1d-a03c-46cc-b8c2-955600950751.gif" width="20%" height="20%">
