### PR TITLE
결제 현황 화면에서 이름이 가나다 순으로 나오도록 수정

### DIFF
--- a/ClassManager/Helper/DataService.swift
+++ b/ClassManager/Helper/DataService.swift
@@ -157,8 +157,11 @@ struct DataService {
     }
     
     func requestAllStudents(of studioID: String) async throws -> [Student]? {
-        let snapshot = try await studentRef.whereField("studioID", isEqualTo: studioID).getDocuments()
-        
+        let snapshot = try await studentRef
+            .whereField("studioID", isEqualTo: studioID)
+            .order(by: "name")
+            .getDocuments()
+            
         return snapshot.documents.compactMap { document in
             try? document.data(as: Student.self)
         }


### PR DESCRIPTION
## 개요
결제 상태 화면에서 이름순으로 나오도록 합니다.

## 작업 내용
1. Cloud Firestore에 복합 색인 추가
<img width="610" alt="image" src="https://user-images.githubusercontent.com/57349859/200902758-1623b03d-bfdd-4de2-b161-803401c6dc09.png">
2. 이름순으로 불러올 수 있도록 앱의 쿼리문 수정

## 고민사항
기본적인 action 에 대한 정의가 부족했던 것 같습니다.
다음 스프린트에선 기술명세 작성 같은걸 통해 이런 부분이 개선할 수 있도록 하겠습니다.

## 스크린샷
<img src = "https://user-images.githubusercontent.com/57349859/200903281-a21b7815-c6e2-47dc-9fa5-2925c5b93d8c.png" width="40%" height="40%">
