### PR TITLE
로그인 화면 및 자동 로그인 구현

### DIFF
--- a/ClassManager.xcodeproj/project.pbxproj
+++ b/ClassManager.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		AB3394B3291503B3001575BB /* SuspendedClasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3394B2291503B3001575BB /* SuspendedClasses.swift */; };
 		AB3394B529150471001575BB /* Student.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3394B429150471001575BB /* Student.swift */; };
 		AB7C6BCE29260F0B0097CD02 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7C6BCD29260F0B0097CD02 /* LoginView.swift */; };
+		AB7C6BDF292673B70097CD02 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = AB7C6BDE292673B70097CD02 /* FirebaseAuth */; };
+		AB7C6BE1292673B70097CD02 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = AB7C6BE0292673B70097CD02 /* FirebaseFirestore */; };
+		AB7C6BE3292673B70097CD02 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = AB7C6BE2292673B70097CD02 /* FirebaseFirestoreSwift */; };
 		AB904815291A8796004567AA /* Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB904814291A8796004567AA /* Encodable.swift */; };
 		AB904817291AAD4F004567AA /* ContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB904816291AAD4F004567AA /* ContainerView.swift */; };
 		AB97798829195F8500C01549 /* StudentInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB97798729195F8500C01549 /* StudentInfoView.swift */; };
@@ -31,8 +34,6 @@
 		C0552C4528F69542005D0E67 /* ClassManagerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0552C4428F69542005D0E67 /* ClassManagerUITests.swift */; };
 		C0552C4728F69542005D0E67 /* ClassManagerUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0552C4628F69542005D0E67 /* ClassManagerUITestsLaunchTests.swift */; };
 		C0552C5428F6965A005D0E67 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C0552C5328F6965A005D0E67 /* GoogleService-Info.plist */; };
-		C0552C5728F69762005D0E67 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = C0552C5628F69762005D0E67 /* FirebaseFirestore */; };
-		C0552C5928F69762005D0E67 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C0552C5828F69762005D0E67 /* FirebaseFirestoreSwift */; };
 		C701B4BB28F7EC4500C94DE3 /* Montserrat-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C701B4BA28F7EC4500C94DE3 /* Montserrat-SemiBold.ttf */; };
 		C701B4BD28F8037200C94DE3 /* Link.swift in Sources */ = {isa = PBXBuildFile; fileRef = C701B4BC28F8037200C94DE3 /* Link.swift */; };
 		C76DC5FA291500DC004E5894 /* AttendanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76DC5F9291500DC004E5894 /* AttendanceView.swift */; };
@@ -129,8 +130,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C0552C5728F69762005D0E67 /* FirebaseFirestore in Frameworks */,
-				C0552C5928F69762005D0E67 /* FirebaseFirestoreSwift in Frameworks */,
+				AB7C6BDF292673B70097CD02 /* FirebaseAuth in Frameworks */,
+				AB7C6BE1292673B70097CD02 /* FirebaseFirestore in Frameworks */,
+				AB7C6BE3292673B70097CD02 /* FirebaseFirestoreSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -327,8 +329,9 @@
 			);
 			name = ClassManager;
 			packageProductDependencies = (
-				C0552C5628F69762005D0E67 /* FirebaseFirestore */,
-				C0552C5828F69762005D0E67 /* FirebaseFirestoreSwift */,
+				AB7C6BDE292673B70097CD02 /* FirebaseAuth */,
+				AB7C6BE0292673B70097CD02 /* FirebaseFirestore */,
+				AB7C6BE2292673B70097CD02 /* FirebaseFirestoreSwift */,
 			);
 			productName = ClassManager;
 			productReference = C0552C2528F69541005D0E67 /* ClassManager.app */;
@@ -403,7 +406,7 @@
 			);
 			mainGroup = C0552C1C28F69541005D0E67;
 			packageReferences = (
-				C0552C5528F69762005D0E67 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				AB7C6BDD292673B70097CD02 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = C0552C2628F69541005D0E67 /* Products */;
 			projectDirPath = "";
@@ -861,25 +864,30 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		C0552C5528F69762005D0E67 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+		AB7C6BDD292673B70097CD02 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
-				kind = exactVersion;
-				version = 9.6.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 9.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		C0552C5628F69762005D0E67 /* FirebaseFirestore */ = {
+		AB7C6BDE292673B70097CD02 /* FirebaseAuth */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C0552C5528F69762005D0E67 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			package = AB7C6BDD292673B70097CD02 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAuth;
+		};
+		AB7C6BE0292673B70097CD02 /* FirebaseFirestore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AB7C6BDD292673B70097CD02 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseFirestore;
 		};
-		C0552C5828F69762005D0E67 /* FirebaseFirestoreSwift */ = {
+		AB7C6BE2292673B70097CD02 /* FirebaseFirestoreSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C0552C5528F69762005D0E67 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			package = AB7C6BDD292673B70097CD02 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseFirestoreSwift;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/ClassManager.xcodeproj/project.pbxproj
+++ b/ClassManager.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		AB2A427028F6E2D000B314B9 /* EnrollmentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2A426F28F6E2D000B314B9 /* EnrollmentListView.swift */; };
 		AB3394B3291503B3001575BB /* SuspendedClasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3394B2291503B3001575BB /* SuspendedClasses.swift */; };
 		AB3394B529150471001575BB /* Student.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3394B429150471001575BB /* Student.swift */; };
+		AB7C6BCE29260F0B0097CD02 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7C6BCD29260F0B0097CD02 /* LoginView.swift */; };
 		AB904815291A8796004567AA /* Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB904814291A8796004567AA /* Encodable.swift */; };
 		AB904817291AAD4F004567AA /* ContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB904816291AAD4F004567AA /* ContainerView.swift */; };
 		AB97798829195F8500C01549 /* StudentInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB97798729195F8500C01549 /* StudentInfoView.swift */; };
@@ -82,6 +83,7 @@
 		AB2A426F28F6E2D000B314B9 /* EnrollmentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrollmentListView.swift; sourceTree = "<group>"; };
 		AB3394B2291503B3001575BB /* SuspendedClasses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuspendedClasses.swift; sourceTree = "<group>"; };
 		AB3394B429150471001575BB /* Student.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Student.swift; sourceTree = "<group>"; };
+		AB7C6BCD29260F0B0097CD02 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		AB904814291A8796004567AA /* Encodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Encodable.swift; sourceTree = "<group>"; };
 		AB904816291AAD4F004567AA /* ContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerView.swift; sourceTree = "<group>"; };
 		AB97798729195F8500C01549 /* StudentInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentInfoView.swift; sourceTree = "<group>"; };
@@ -275,6 +277,7 @@
 				AB97798729195F8500C01549 /* StudentInfoView.swift */,
 				AB904816291AAD4F004567AA /* ContainerView.swift */,
 				C76DC6252922A984004E5894 /* LaunchScreenView.swift */,
+				AB7C6BCD29260F0B0097CD02 /* LoginView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -477,6 +480,7 @@
 				C79E13C028F6B1780010C4BA /* Class.swift in Sources */,
 				C76DC5FC291547F2004E5894 /* Date.swift in Sources */,
 				C79E13CF28F6BC580010C4BA /* Constant.swift in Sources */,
+				AB7C6BCE29260F0B0097CD02 /* LoginView.swift in Sources */,
 				ABDABFE529169CF2001B5256 /* CustomSearchBar.swift in Sources */,
 				C79E13D728F6BCFD0010C4BA /* FontManager.swift in Sources */,
 				ABDABFE729169D8C001B5256 /* PaymentStatusView.swift in Sources */,

--- a/ClassManager/ClassManagerApp.swift
+++ b/ClassManager/ClassManagerApp.swift
@@ -24,7 +24,7 @@ struct ClassManagerApp: App {
     
     var body: some Scene {
         WindowGroup {
-            LoginView()
+            LaunchScreenView()
         }
     }
 }

--- a/ClassManager/ClassManagerApp.swift
+++ b/ClassManager/ClassManagerApp.swift
@@ -24,7 +24,7 @@ struct ClassManagerApp: App {
     
     var body: some Scene {
         WindowGroup {
-            LaunchScreenView()
+            LoginView()
         }
     }
 }

--- a/ClassManager/Helper/DataService.swift
+++ b/ClassManager/Helper/DataService.swift
@@ -12,6 +12,8 @@ import FirebaseFirestoreSwift
 struct DataService {
     static let shared = DataService()
     
+    private init() {}
+    
     let studioRef = Firestore.firestore().collection("studios")
     let classRef = Firestore.firestore().collection("classes")
     let linkRef = Firestore.firestore().collection("link")
@@ -19,8 +21,8 @@ struct DataService {
     let suspendedRef = Firestore.firestore().collection("suspended")
     let studentRef = Firestore.firestore().collection("student")
     
-    func createStudio(ID: String, name: String, location: String?, notice: Notice?, halls: [Hall]) {
-        let studio = Studio(ID: ID, name: name, location: location, notice: notice, halls: halls)
+    func createStudio(ID: String, email: String, name: String, location: String?, notice: Notice?, halls: [Hall]) {
+        let studio = Studio(ID: ID, email: email, name: name, location: location, notice: notice, halls: halls)
         do {
             try studioRef.document("\(ID)").setData(from: studio)
         } catch let error {

--- a/ClassManager/Helper/DataService.swift
+++ b/ClassManager/Helper/DataService.swift
@@ -47,6 +47,14 @@ struct DataService {
         }
     }
     
+    func requestStudioBy(email: String) async throws -> Studio? {
+        let snapshot = try await studioRef.whereField("email", isEqualTo: email).getDocuments()
+        
+        return try snapshot.documents.compactMap { document in
+            try document.data(as: Studio.self)
+        }.first
+    }
+    
     func requestStudioBy(studioID: String) async throws -> Studio? {
         let document = try await studioRef.document(studioID).getDocument()
         

--- a/ClassManager/Model/Studio.swift
+++ b/ClassManager/Model/Studio.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct Studio: Codable {
     let ID: String
+    let email: String
     let name: String?
     let location: String?
     let notice: Notice?

--- a/ClassManager/View/LoginView.swift
+++ b/ClassManager/View/LoginView.swift
@@ -82,6 +82,7 @@ struct LoginView: View {
     func login() async {
         do {
             let _ = try await FirebaseAuth.Auth.auth().signIn(withEmail: emailInput, password: passwordInput)
+            studioID = try await DataService.shared.requestStudioBy(email: emailInput)?.ID
         } catch {
             isLoginAlertPresented = true
         }

--- a/ClassManager/View/LoginView.swift
+++ b/ClassManager/View/LoginView.swift
@@ -6,12 +6,15 @@
 //
 
 import SwiftUI
+import FirebaseAuth
 
 struct LoginView: View {
     @State private var emailInput = ""
     @State private var passwordInput = ""
+    @State private var isLoginAlertPresented = false
     @FocusState private var typingEmail: Bool
     @FocusState private var typingPassword: Bool
+    @AppStorage("studioID") private var studioID: String?
     
     var body: some View {
         VStack(spacing: 0) {
@@ -48,6 +51,9 @@ struct LoginView: View {
                 typingEmail = false
                 typingPassword = false
                 // TODO: 로그인 로직
+                Task {
+                    await login()
+                }
             } label: {
                 Text("로그인")
                     .font(.system(size: 17, weight: .semibold))
@@ -62,6 +68,22 @@ struct LoginView: View {
         .onTapGesture {
             typingEmail = false
             typingPassword = false
+        }
+        .alert("이메일•비밀번호", isPresented: $isLoginAlertPresented) {
+            Button("OK") {
+                isLoginAlertPresented = false
+            }
+        } message: {
+            Text("존재하지 않는 이메일 또는 비밀번호입니다.\n다시 시도하거나 기술지원팀에 연락하세요.")
+        }
+
+    }
+    
+    func login() async {
+        do {
+            let _ = try await FirebaseAuth.Auth.auth().signIn(withEmail: emailInput, password: passwordInput)
+        } catch {
+            isLoginAlertPresented = true
         }
     }
 }

--- a/ClassManager/View/LoginView.swift
+++ b/ClassManager/View/LoginView.swift
@@ -39,9 +39,14 @@ struct LoginView: View {
                 LoginTextField(placeHolder: "비밀번호를 입력하세요.", isPassword: true, text: $passwordInput, focused: $typingPassword)
             }
             .font(.system(size: 15))
-            .padding(.bottom, 131)
+            
+            Rectangle()
+                .frame(height: 131)
+                .foregroundColor(Color(.systemBackground))
             
             Button {
+                typingEmail = false
+                typingPassword = false
                 // TODO: 로그인 로직
             } label: {
                 Text("로그인")
@@ -50,12 +55,14 @@ struct LoginView: View {
                     .padding(.vertical, 17)
                     .foregroundColor(.black)
                     .background(RoundedRectangle(cornerRadius: 10).foregroundColor(.accent))
-                    .padding(.bottom, 19)
-                    
             }
-
+            .padding(.bottom, 19)
         }
         .padding(.horizontal, 20)
+        .onTapGesture {
+            typingEmail = false
+            typingPassword = false
+        }
     }
 }
 

--- a/ClassManager/View/LoginView.swift
+++ b/ClassManager/View/LoginView.swift
@@ -1,0 +1,83 @@
+//
+//  LoginView.swift
+//  ClassManager
+//
+//  Created by 김남건 on 2022/11/17.
+//
+
+import SwiftUI
+
+struct LoginView: View {
+    @State private var emailInput = ""
+    @State private var passwordInput = ""
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            Image("Logo")
+                .resizable()
+                .frame(width: 151, height: 151)
+                .padding(.bottom, 27)
+            
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("환영합니다.")
+                    HStack(spacing: 0) {
+                        Text("번트 매니저")
+                            .foregroundColor(.accent)
+                        Text("에 로그인해주세요.")
+                    }
+                }
+                .font(.system(size: 17, weight: .medium))
+                Spacer()
+            }
+            .padding(.bottom, 27)
+            
+            VStack(spacing: 18) {
+                LoginTextField(placeHolder: "이메일을 입력하세요.", isPassword: false, text: $emailInput)
+                LoginTextField(placeHolder: "비밀번호를 입력하세요.", isPassword: true, text: $passwordInput)
+            }
+            .font(.system(size: 15))
+            .padding(.bottom, 131)
+            
+            Button {
+                // TODO: 로그인 로직
+            } label: {
+                Text("로그인")
+                    .font(.system(size: 17, weight: .semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 17)
+                    .foregroundColor(.black)
+                    .background(RoundedRectangle(cornerRadius: 10).foregroundColor(.accent))
+                    .padding(.bottom, 19)
+                    
+            }
+
+        }
+        .padding(.horizontal, 20)
+    }
+}
+
+struct LoginTextField: View {
+    let placeHolder: String
+    let isPassword: Bool
+    @Binding var text: String
+    
+    var body: some View {
+        Group {
+            if isPassword {
+                SecureField(placeHolder, text: $text)
+            } else {
+                TextField(placeHolder, text: $text)
+            }
+        }
+        .textInputAutocapitalization(.none)
+        .padding(15)
+        .background(RoundedRectangle(cornerRadius: 10).foregroundColor(Color("ToastBackground")))
+    }
+}
+
+struct LoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoginView()
+    }
+}

--- a/ClassManager/View/LoginView.swift
+++ b/ClassManager/View/LoginView.swift
@@ -86,13 +86,14 @@ struct LoginTextField: View {
             Group {
                 if isPassword {
                     SecureField(placeHolder, text: $text)
+                        
                 } else {
                     TextField(placeHolder, text: $text)
                 }
             }
+            .textInputAutocapitalization(.never)
             .padding(15)
             .focused(focused)
-            .textInputAutocapitalization(.none)
         }
     }
 }

--- a/ClassManager/View/LoginView.swift
+++ b/ClassManager/View/LoginView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct LoginView: View {
     @State private var emailInput = ""
     @State private var passwordInput = ""
+    @FocusState private var typingEmail: Bool
+    @FocusState private var typingPassword: Bool
     
     var body: some View {
         VStack(spacing: 0) {
@@ -33,8 +35,8 @@ struct LoginView: View {
             .padding(.bottom, 27)
             
             VStack(spacing: 18) {
-                LoginTextField(placeHolder: "이메일을 입력하세요.", isPassword: false, text: $emailInput)
-                LoginTextField(placeHolder: "비밀번호를 입력하세요.", isPassword: true, text: $passwordInput)
+                LoginTextField(placeHolder: "이메일을 입력하세요.", isPassword: false, text: $emailInput, focused: $typingEmail)
+                LoginTextField(placeHolder: "비밀번호를 입력하세요.", isPassword: true, text: $passwordInput, focused: $typingPassword)
             }
             .font(.system(size: 15))
             .padding(.bottom, 131)
@@ -61,18 +63,37 @@ struct LoginTextField: View {
     let placeHolder: String
     let isPassword: Bool
     @Binding var text: String
+    var focused: FocusState<Bool>.Binding {
+        didSet {
+            print(focused.wrappedValue)
+        }
+    }
     
     var body: some View {
-        Group {
-            if isPassword {
-                SecureField(placeHolder, text: $text)
-            } else {
-                TextField(placeHolder, text: $text)
+        ZStack {
+            RoundedRectangle(cornerRadius: 10)
+                .foregroundColor(Color("ToastBackground"))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(focused.wrappedValue ? .white : Color("ToastBackground"), lineWidth: 1)
+                        .frame(height: 50)
+                }
+                .frame(height: 50)
+                .onTapGesture {
+                    focused.projectedValue.wrappedValue = true
+                }
+            
+            Group {
+                if isPassword {
+                    SecureField(placeHolder, text: $text)
+                } else {
+                    TextField(placeHolder, text: $text)
+                }
             }
+            .padding(15)
+            .focused(focused)
+            .textInputAutocapitalization(.none)
         }
-        .textInputAutocapitalization(.none)
-        .padding(15)
-        .background(RoundedRectangle(cornerRadius: 10).foregroundColor(Color("ToastBackground")))
     }
 }
 


### PR DESCRIPTION
## 개요
* 로그인 화면 구현
* 자동 로그인 위해 UserDefaults에 studioID 저장

## 작업 내용
* [LoginView.swift]
    * 로그인 시 각 text field가 focus 되면서 흰색 테두리가 보이도록 구현
    * text field 외의 영역 누를 시 focus 잃도록 함
    * 로그인 성공 시 `UserDefaults`에 `studioID` 저장, 실패 시 alert 창 뜨도록 함
        * `studioID` 필요한 view에서 `String?` 타입의 `@AppStorage` 프로퍼티 선언하면 됨
        * `studioID` 값이 `nil`이 아니면 로그인된 상태로 판단

* [DataService.swift]
    * `requestStudioBy(email:)` 메서드 추가
        * `email`로 `Studio` 구조체를 받는 메서드
        * firebase에 있는 데이터에서도 `email` 필드 추가 완료

* [Studio.swift]
    * `email` 프로퍼티 추가

## 고민사항


## 테스트 방법(optional)
* root view를 임시로 LoginView로 바꾼 다음 시뮬레이터로 실행

## 스크린샷

https://user-images.githubusercontent.com/40821203/202492930-c982fbb8-4b95-48c6-a8ef-4c46db897d32.mov

