### PR TITLE
뷰 통합 및 데이터 연결 로직 변경

### DIFF
--- a/ClassManager.xcodeproj/project.pbxproj
+++ b/ClassManager.xcodeproj/project.pbxproj
@@ -42,8 +42,8 @@
 		C76DC60029163F52004E5894 /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76DC5FF29163F52004E5894 /* View.swift */; };
 		C76DC60229164889004E5894 /* EditClassView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76DC60129164889004E5894 /* EditClassView.swift */; };
 		C76DC624291FC451004E5894 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76DC623291FC451004E5894 /* String.swift */; };
-		C76DC6282923B3AC004E5894 /* WeeklyCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76DC6272923B3AC004E5894 /* WeeklyCalendarView.swift */; };
 		C76DC6262922A984004E5894 /* LaunchScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76DC6252922A984004E5894 /* LaunchScreenView.swift */; };
+		C76DC6282923B3AC004E5894 /* WeeklyCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76DC6272923B3AC004E5894 /* WeeklyCalendarView.swift */; };
 		C79E13BC28F6AF8B0010C4BA /* Studio.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79E13BB28F6AF8B0010C4BA /* Studio.swift */; };
 		C79E13BE28F6B0DC0010C4BA /* Notice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79E13BD28F6B0DC0010C4BA /* Notice.swift */; };
 		C79E13C028F6B1780010C4BA /* Class.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79E13BF28F6B1780010C4BA /* Class.swift */; };
@@ -112,8 +112,8 @@
 		C76DC5FF29163F52004E5894 /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
 		C76DC60129164889004E5894 /* EditClassView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditClassView.swift; sourceTree = "<group>"; };
 		C76DC623291FC451004E5894 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
-		C76DC6272923B3AC004E5894 /* WeeklyCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyCalendarView.swift; sourceTree = "<group>"; };
 		C76DC6252922A984004E5894 /* LaunchScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenView.swift; sourceTree = "<group>"; };
+		C76DC6272923B3AC004E5894 /* WeeklyCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyCalendarView.swift; sourceTree = "<group>"; };
 		C79E13BB28F6AF8B0010C4BA /* Studio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Studio.swift; sourceTree = "<group>"; };
 		C79E13BD28F6B0DC0010C4BA /* Notice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notice.swift; sourceTree = "<group>"; };
 		C79E13BF28F6B1780010C4BA /* Class.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Class.swift; sourceTree = "<group>"; };

--- a/ClassManager/ClassManager.entitlements
+++ b/ClassManager/ClassManager.entitlements
@@ -2,9 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.Bunt.ClassManager</string>
+	</array>
 </dict>
 </plist>

--- a/ClassManager/Helper/Constant.swift
+++ b/ClassManager/Helper/Constant.swift
@@ -44,4 +44,19 @@ class Constant {
         }
         return false
     }
+    
+    func fetchLink(id: String) async -> String {
+        do {
+            let linkStruct = try await DataService.shared.requestLink(studioID: id)
+            Constant.shared.studio = try await DataService.shared.requestStudioBy(studioID: id)
+            Constant.shared.classes = try await DataService.shared.requestAllClassesBy(studioID: id)
+            Constant.shared.suspendedClasses = try await DataService.shared.requestSuspendedClassesBy(studioID: id)
+            if linkStruct != nil {
+                return linkStruct!.link!
+            }
+        } catch {
+            print(error)
+        }
+        return ""
+    }
 }

--- a/ClassManager/Helper/Constant.swift
+++ b/ClassManager/Helper/Constant.swift
@@ -51,8 +51,8 @@ class Constant {
             Constant.shared.studio = try await DataService.shared.requestStudioBy(studioID: id)
             Constant.shared.classes = try await DataService.shared.requestAllClassesBy(studioID: id)
             Constant.shared.suspendedClasses = try await DataService.shared.requestSuspendedClassesBy(studioID: id)
-            if linkStruct != nil {
-                return linkStruct!.link!
+            if let linkStruct, let link = linkStruct.link {
+                return link
             }
         } catch {
             print(error)

--- a/ClassManager/Helper/DataService.swift
+++ b/ClassManager/Helper/DataService.swift
@@ -77,8 +77,8 @@ struct DataService {
         }
     }
     
-    func requestLink() async throws -> Link? {
-        let document = try await linkRef.document("sampleLink").getDocument()
+    func requestLink(studioID: String) async throws -> Link? {
+        let document = try await linkRef.document(studioID).getDocument()
         
         return try? document.data(as: Link.self)
     }

--- a/ClassManager/Helper/DataService.swift
+++ b/ClassManager/Helper/DataService.swift
@@ -190,7 +190,7 @@ struct DataService {
             enrollmentRef.document("\(enrollment.ID)").updateData([
                 "paid": enrollment.paid ?? false,
                 "isRefunded": enrollment.isRefunded ?? false,
-                "refundReason": enrollment.refundReason
+                "refundReason": enrollment.refundReason ?? ""
             ]) { err in
                 if let err = err {
                     print("Error updating document: \(err)")

--- a/ClassManager/View/ClassCalendarView.swift
+++ b/ClassManager/View/ClassCalendarView.swift
@@ -15,7 +15,6 @@ struct ClassCalendarView: View {
     @State private var selectedDate = Date()
     @State private var classesToday = [Class]()
     
-    // TODO: 신청폼 링크 실제 데이터로 교체
     let link: String
     let studioID: String
     
@@ -112,6 +111,11 @@ struct ClassCalendarView: View {
             }
         }
         .onChange(of: isShowingAddSheet) { _ in
+            if let classes = Constant.shared.classes {
+                classesToday = classes.filter{ $0.date != nil && Calendar.current.isDate($0.date!, inSameDayAs: selectedDate) }
+            }
+        }
+        .onChange(of: Constant.shared.classes?.count) { _ in
             if let classes = Constant.shared.classes {
                 classesToday = classes.filter{ $0.date != nil && Calendar.current.isDate($0.date!, inSameDayAs: selectedDate) }
             }

--- a/ClassManager/View/LaunchScreenView.swift
+++ b/ClassManager/View/LaunchScreenView.swift
@@ -13,16 +13,20 @@ struct LaunchScreenView: View {
     @State private var opacity = 0.5
     
     @AppStorage("onboarding") var isOnboardingActive: Bool = true
+    @AppStorage("studioID") private var studioID: String?
     
     @State var link = "https://this.is.sample.link"
-    @State var studioID = ""
     
     var body: some View {
         if isActive {
             if isOnboardingActive {
                 OnboardingMain()
             } else {
-                ContainerView(link: self.link, studioID: self.studioID)
+                if let id = studioID {
+                    ContainerView(link: self.link, studioID: id)
+                } else {
+                    LoginView(link: $link)
+                }
             }
         } else {
             Image("Logo")
@@ -35,20 +39,8 @@ struct LaunchScreenView: View {
                     }
                 }
                 .task {
-                    do {
-                        // 임시 테스트 플라이트용 함수
-                        let linkStruct = try await DataService.shared.requestLink()
-                        if linkStruct != nil {
-                            link = linkStruct!.link!
-                            studioID = linkStruct!.studioID!
-                        }
-                        if !studioID.isEmpty {
-                            Constant.shared.studio = try await DataService.shared.requestStudioBy(studioID: studioID)
-                            Constant.shared.classes = try await DataService.shared.requestAllClassesBy(studioID: studioID)
-                        }
-                        Constant.shared.suspendedClasses = try await DataService.shared.requestSuspendedClassesBy(studioID: studioID)
-                    } catch {
-                        print(error)
+                    if let id = studioID {
+                        link = await Constant.shared.fetchLink(id: id)
                     }
                 }
         }

--- a/ClassManager/View/LoginView.swift
+++ b/ClassManager/View/LoginView.swift
@@ -16,6 +16,8 @@ struct LoginView: View {
     @FocusState private var typingPassword: Bool
     @AppStorage("studioID") private var studioID: String?
     
+    @Binding var link: String
+    
     var body: some View {
         VStack(spacing: 0) {
             Image("Logo")
@@ -50,7 +52,6 @@ struct LoginView: View {
             Button {
                 typingEmail = false
                 typingPassword = false
-                // TODO: 로그인 로직
                 Task {
                     await login()
                 }
@@ -83,7 +84,11 @@ struct LoginView: View {
         do {
             let _ = try await FirebaseAuth.Auth.auth().signIn(withEmail: emailInput, password: passwordInput)
             studioID = try await DataService.shared.requestStudioBy(email: emailInput)?.ID
+            if let id = studioID {
+                link = await Constant.shared.fetchLink(id: id)
+            }
         } catch {
+            print(error)
             isLoginAlertPresented = true
         }
     }
@@ -130,6 +135,6 @@ struct LoginTextField: View {
 
 struct LoginView_Previews: PreviewProvider {
     static var previews: some View {
-        LoginView()
+        LoginView(link: .constant(""))
     }
 }


### PR DESCRIPTION
## 개요
- #46 
- 뷰 통합 및 데이터 연결 로직 변경

## 작업 내용
- 로그인 뷰를 플로우에 통합했습니다.
- FirebaseAuth 이슈 해결을 위해 Keychain sharing을 추가하였습니다.
- Firebase에서 링크를 불러오는 함수 내부의 더미 데이터를 실제 데이터로 교체하였습니다.
- Firebase에서 데이터를 fetch해오는 로직을 통합된 플로우에 맞게 수정했습니다.
- 로그인 정보를 이용하여 데이터를 불러오는 기능을 구현하였습니다.

## 고민사항
- 주말에 실기기를 연결해 테스트해봐야 합니다.

## 테스트 방법(optional)
id: bunt.studio@gmail.com
password: 12345678

## 스크린샷
![Simulator Screen Recording - iPhone 14 Pro - 2022-11-18 at 16 49 42](https://user-images.githubusercontent.com/59128435/202649291-e581058e-e9e4-45e8-9d74-6095a3f875be.gif)
