### PR TITLE
수강생 정보 화면에서 쿠폰의 필터링 로직 수정

### DIFF
--- a/ClassManager/View/StudentInfoView.swift
+++ b/ClassManager/View/StudentInfoView.swift
@@ -90,16 +90,14 @@ struct StudentInfoView: View {
             ScrollView(.horizontal) {
                 HStack(spacing: 14) {
                     Group {
-                        if student.coupons.isEmpty {
+                        if student.availableCoupons.isEmpty {
                             Text("구매한 쿠폰이 없습니다.")
                                 .font(.system(size: 15))
                                 .foregroundColor(Color("InfoText"))
                                 .frame(height: 140, alignment: .top)
                         } else {
                             ForEach(student.groupedCoupons, id: \.[0].expiredDate) { group in
-                                if group[0].expiredDate != nil && group[0].expiredDate!.dateGap(from: Date()) >= 0 {
-                                    couponView(couponGroup: group)
-                                }
+                                couponView(couponGroup: group)
                             }
                         }
                     }


### PR DESCRIPTION
## 개요
* 수강생 정보 화면에서 쿠폰의 필터링 로직 수정

## 작업 내용
* 아직 기한이 지나지 않으면서 클래스 신청에 사용되지 않은 쿠폰만 "남은 쿠폰" 목록에 보이도록 수정
* availableCoupons: 아직 기한이 지나지 않으면서 클래스 신청에 사용되지 않은 쿠폰들을 리턴
* groupedCoupons에서 availableCoupons를 가지고 grouping하도록 수정

## 고민사항
* firebase의 일부 쿠폰 데이터에서 `classID`가 `nil`이 아닌데도 `nil`로 받아오게 되는 경우가 존재
* firebase 자체의 문제인듯

## 테스트 방법(optional)
* 수강생 정보 화면의 남은 쿠폰 목록과 firebase 데이터를 대조하여 확인

## 스크린샷
* 강지인 수강생이 쿠폰이 4개인데 1개는 클래스 신청에 사용된 상태

<img src="https://user-images.githubusercontent.com/40821203/203502042-bc3c05df-9db3-44d4-b9aa-b3316046e82d.png" width=195 height=422/>
