### PR TITLE
수강생 화면에서 결제 환불 시 쿠폰 정보 수정

### DIFF
--- a/ClassManager/Extensions/Encodable.swift
+++ b/ClassManager/Extensions/Encodable.swift
@@ -26,3 +26,21 @@ extension Array where Element: Enrollment {
         return try self.map { try $0.encode() }
     }
 }
+
+extension Coupon {
+    func encode() throws -> [String: Any] {
+        let data = try JSONEncoder().encode(self)
+        guard var dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any] else {
+            throw NSError()
+        }
+        
+        dictionary["expiredDate"] = Timestamp(date: expiredDate ?? Date())
+        return dictionary
+    }
+}
+
+extension Array where Element: Coupon {
+    func encode() throws -> [[String: Any]] {
+        return try self.map { try $0.encode() }
+    }
+}

--- a/ClassManager/Helper/DataService.swift
+++ b/ClassManager/Helper/DataService.swift
@@ -222,12 +222,16 @@ struct DataService {
     }
     
     func updateStudentCoupons(student: Student, coupons: [Coupon]) {
-        studentRef.document("\(student.ID)").updateData([
-            "coupons": coupons
-        ]) { err in
-            if let err = err {
-                print("Error updating document: \(err)")
+        do {
+            studentRef.document("\(student.ID)").updateData([
+                "coupons": try coupons.encode()
+            ]) { err in
+                if let err = err {
+                    print("Error updating document: \(err)")
+                }
             }
+        } catch {
+            print(error)
         }
     }
     

--- a/ClassManager/Model/Enrollment.swift
+++ b/ClassManager/Model/Enrollment.swift
@@ -54,4 +54,8 @@ class Enrollment: Codable {
     func findClass(in classes: [Class]) {
         matchedClass = classes.filter { $0.ID == self.classID }.first
     }
+    
+    func isRefundedInServer(coupons: [Coupon]) -> Bool {
+        coupons.filter { $0.classID == self.classID }.isEmpty
+    }
 }


### PR DESCRIPTION
## 개요
* 수강생 화면에서 결제 환불 시 쿠폰 정보 수정

## 작업 내용
* [StudentInfoView.swift]
    * 결제 내역에서 환불 여부 체크 이후 저장 버튼 누를 시 쿠폰이 회복되도록 함
    * 서버에도 이미 환불 처리가 되어 있다면 환불 취소를 못하도록 함

* [Enrollment.swift]
    * `isRefundedInServer`: 서버에도 환불 완료 처리되어 있는지를 확인하는 메서드

* [Encodable.swift]
    * `Coupon.encode()`: `Coupon` 데이터를 `[String:Any]`로 변환하여 firebase에 올릴 수 있도록 함

## 고민사항
* `Enrollment`의 `isRefundedInServer`의 경우 `enrollment`의 `classID`와 일치하는 `coupon`이 있는지를 확인하는 방식으로 처리
    * 추후에 수정 필요할듯

## 테스트 방법(optional)
* 결제 내역에서 환불 체크 후 저장 버튼 눌러서 쿠폰 회복되는지 확인하기

## 스크린샷

https://user-images.githubusercontent.com/40821203/203729573-2d668884-ce69-4016-9c75-d7ed49e41012.mov


